### PR TITLE
Add/implement mouse selections

### DIFF
--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -1323,7 +1323,7 @@ mod tests {
         editor.move_up();
         assert_eq!(render_selections(&editor), vec![empty_selection(0, 1)]);
 
-        // Select to a direct point work in front of cursor position
+        // Select to a direct point in front of cursor position
         editor.select_to(Point::new(1, 0));
         assert_eq!(render_selections(&editor), vec![selection((0, 1), (1, 0))]);
         editor.move_right(); // cancel selection
@@ -1332,7 +1332,7 @@ mod tests {
         editor.move_right();
         assert_eq!(render_selections(&editor), vec![empty_selection(2, 1)]);
 
-        // Selection can go to a point before the cursor
+        // Selection can even go to a point before the cursor (with reverse)
         editor.select_to(Point::new(0, 0));
         assert_eq!(render_selections(&editor), vec![rev_selection((0, 0), (2, 1))]);
 

--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -513,27 +513,6 @@ impl BufferView {
         self.autoscroll_to_cursor(false);
     }
 
-
-    // pub fn set_cursor_position(&mut self, position: Point, autoscroll: bool) {
-    //     self.buffer
-    //         .borrow_mut()
-    //         .mutate_selections(self.selection_set_id, |buffer, selections| {
-    //             // TODO: Clip point or return a result.
-    //             let anchor = buffer.anchor_before_point(position).unwrap();
-    //             selections.clear();
-    //             selections.push(Selection {
-    //                 start: anchor.clone(),
-    //                 end: anchor,
-    //                 reversed: false,
-    //                 goal_column: None,
-    //             });
-    //         })
-    //         .unwrap();
-    //     if autoscroll {
-    //         self.autoscroll_to_cursor(false);
-    //     }
-    // }
-
     pub fn select_to(&mut self, position: Point) {
         self.buffer
             .borrow_mut()

--- a/xray_core/src/buffer_view.rs
+++ b/xray_core/src/buffer_view.rs
@@ -70,6 +70,10 @@ enum BufferViewAction {
     SelectDown,
     SelectLeft,
     SelectRight,
+    SelectTo {
+        row: u32,
+        column: u32,
+    },
     SelectToBeginningOfWord,
     SelectToEndOfWord,
     SelectToBeginningOfLine,
@@ -502,6 +506,42 @@ impl BufferView {
                         .anchor_before_point(movement::right(&buffer, head))
                         .unwrap();
                     selection.set_head(&buffer, cursor);
+                    selection.goal_column = None;
+                }
+            })
+            .unwrap();
+        self.autoscroll_to_cursor(false);
+    }
+
+
+    // pub fn set_cursor_position(&mut self, position: Point, autoscroll: bool) {
+    //     self.buffer
+    //         .borrow_mut()
+    //         .mutate_selections(self.selection_set_id, |buffer, selections| {
+    //             // TODO: Clip point or return a result.
+    //             let anchor = buffer.anchor_before_point(position).unwrap();
+    //             selections.clear();
+    //             selections.push(Selection {
+    //                 start: anchor.clone(),
+    //                 end: anchor,
+    //                 reversed: false,
+    //                 goal_column: None,
+    //             });
+    //         })
+    //         .unwrap();
+    //     if autoscroll {
+    //         self.autoscroll_to_cursor(false);
+    //     }
+    // }
+
+    pub fn select_to(&mut self, position: Point) {
+        self.buffer
+            .borrow_mut()
+            .mutate_selections(self.selection_set_id, |buffer, selections| {
+                for selection in selections.iter_mut() {
+                    let old_head = buffer.point_for_anchor(selection.head()).unwrap();
+                    let anchor = buffer.anchor_before_point(position).unwrap();
+                    selection.set_head(buffer, anchor);
                     selection.goal_column = None;
                 }
             })
@@ -1086,6 +1126,10 @@ impl View for BufferView {
             Ok(BufferViewAction::SelectDown) => self.select_down(),
             Ok(BufferViewAction::SelectLeft) => self.select_left(),
             Ok(BufferViewAction::SelectRight) => self.select_right(),
+            Ok(BufferViewAction::SelectTo {
+                row,
+                column
+            }) => self.select_to(Point::new(row, column)),
             Ok(BufferViewAction::SelectToBeginningOfWord) => self.select_to_beginning_of_word(),
             Ok(BufferViewAction::SelectToEndOfWord) => self.select_to_end_of_word(),
             Ok(BufferViewAction::SelectToBeginningOfLine) => self.select_to_beginning_of_line(),

--- a/xray_ui/lib/text_editor/text_editor.js
+++ b/xray_ui/lib/text_editor/text_editor.js
@@ -247,9 +247,12 @@ class TextEditor extends React.Component {
 
   handleMouseMove(event) {
     if (this.canUseTextPlane() && this.state.mouseDown) {
-      this.props.dispatch(Object.assign({
-        type: "SelectTo",
-      }, this.getPositionFromMouseEvent(event)));
+      const pos = this.getPositionFromMouseEvent(event);
+      if (pos) {
+        this.props.dispatch(Object.assign({
+          type: "SelectTo",
+        }, pos));
+      }
     }
   }
 
@@ -274,10 +277,13 @@ class TextEditor extends React.Component {
 
   handleClick(event) {
     this.pauseCursorBlinking();
+    const pos = this.getPositionFromMouseEvent(event);
+    if (pos) {
       this.props.dispatch(Object.assign({
         type: "SetCursorPosition",
         autoscroll: false
-      }, this.getPositionFromMouseEvent(event)));
+      }, pos));
+    }
   }
 
   handleDoubleClick() {

--- a/xray_ui/lib/text_editor/text_editor.js
+++ b/xray_ui/lib/text_editor/text_editor.js
@@ -279,10 +279,16 @@ class TextEditor extends React.Component {
     this.pauseCursorBlinking();
     const pos = this.getPositionFromMouseEvent(event);
     if (pos) {
-      this.props.dispatch(Object.assign({
-        type: "SetCursorPosition",
-        autoscroll: false
-      }, pos));
+      if (event.shiftKey) {
+        this.props.dispatch(Object.assign({
+          type: "SelectTo"
+        }, pos));
+      } else {
+        this.props.dispatch(Object.assign({
+          type: "SetCursorPosition",
+          autoscroll: false
+        }, pos));
+      }
     }
   }
 


### PR DESCRIPTION
@pranaygp I had a look at the PR and found the potential issue: `animationFrameLoop` was being called recursively. 

I moved it to `TextEditor.handleMouseMove` where I exit from it early when `this.state.mouseDown` is `false`, avoid calling `window.requestAnimationFrame`.

It has been a long time, but if you have a chance to ensure my changes are not breaking something else that I'm not seeing it would be amazing.

Original PR: atom#107